### PR TITLE
fix the conflict with wet mrgn and list-inline classes in overlay.css

### DIFF
--- a/src/InvitationManager.js
+++ b/src/InvitationManager.js
@@ -577,9 +577,9 @@ function imSetup() {
 			"</header>" +
 			"<div class='gc-im-modal-body'>" +
 				survey["body-" + wb_im.lang] +
-				"<ul class='list-inline mrgn-tp-md'>" +
-					"<li class='mrgn-tp-md marginBottom-yes'><a id='survey-yes' class='gc-im-btn gc-im-btn-primary' href='" + survey["link-" + wb_im.lang] + "' target='_blank'>" + survey["yes-" + wb_im.lang] + "</a></li> " + 
-					"<li class='mrgn-tp-md marginBottom-no'><button id='survey-no' class='gc-im-btn gc-im-btn-secondary survey-close'>" + survey["no-" + wb_im.lang] + "</button></li>" +
+				"<ul class='list-inline mrgn-sm'>" +
+					"<li class='mrgn-sm marginBottom-yes'><a id='survey-yes' class='gc-im-btn gc-im-btn-primary' href='" + survey["link-" + wb_im.lang] + "' target='_blank'>" + survey["yes-" + wb_im.lang] + "</a></li> " + 
+					"<li class='mrgn-sm marginBottom-no'><button id='survey-no' class='gc-im-btn gc-im-btn-secondary survey-close'>" + survey["no-" + wb_im.lang] + "</button></li>" +
 				"</ul>" +
 				popupInput +
 			"</div>" +

--- a/src/Overlay.css
+++ b/src/Overlay.css
@@ -94,12 +94,12 @@
 	outline: 0;
 }
 
-.list-inline {
+#gc-im-popup .list-inline {
 	padding-left: 0;
 	list-style: none;
 }
-					
-.mrgn-tp-md  { 
+
+#gc-im-popup .mrgn-sm { 
 	margin: 5px; 
 }
 
@@ -224,7 +224,9 @@ a.gc-im-btn {
 }
 
 #gc-im-popup ul.list-inline li{ 
-	display: inline; 	
+	display: inline; 
+	padding-left: 5px;
+	padding-right: 5px;	
 }
 				
 #gc-im-popup ul li {
@@ -273,8 +275,8 @@ a.gc-im-btn {
 	float: right;
 }
 
-.gc-im-modal-modal-header div.clearfix::after {
-	content: “”;
+#gc-im-popup div.clearfix::after {
+	content: " ";
 	clear: both;
 	display: table;
 }


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

Close #5 :

- `mrgn-tp-md` CSS class name is replaced with `mrgn-sm` in order to correspond to the applied CSS rule (margin: 5px);
- encaspulate `list-inline` and `mrgn-sm` classes to avoid CSS rules conflict with WET-BOEW
- CSS fix for IM popup header for non WET-BOEW implementation