### PR TITLE
WET-255 - GC Task Success Survey: Survey Referrer value being cut-off

### DIFF
--- a/docs/im.json
+++ b/docs/im.json
@@ -74,7 +74,7 @@
     "close-fr" : "Fermer : Sondage de fin de visite (touche d&apos;échappement)",
     "name" : "ESDC - MSCA Feedback Form - Thank you page",
     "survey-urls" : [
-      {"url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM"}
+      {"url" : "/invitation-manager/docs/test-IM"}
     ]
   },
   {
@@ -97,8 +97,8 @@
     "close-fr" : "Fermer : Sondage de fin de visite (touche d&apos;échappement)",
     "name" : "ESDC - MSCA Feedback Form - Thank you page",
     "survey-urls" : [
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test-eng.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test-fra.html"}
+			{ "url" : "/invitation-manager/docs/test-IM/test-eng.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test-fra.html"}
 			
     ]
   },
@@ -123,10 +123,10 @@
     "close-fr" : "Fermer : Sondage de fin de visite (touche d&apos;échappement)",
     "name" : "ESDC - MSCA Feedback Form",
     "survey-urls" : [
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test2-eng.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test2-fra.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test3-eng.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test3-fra.html"}
+			{ "url" : "/invitation-manager/docs/test-IM/test2-eng.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test2-fra.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test3-eng.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test3-fra.html"}
 	
     ]
   },
@@ -151,8 +151,8 @@
     "close-fr" : "Fermer : Sondage de fin de visite (touche d&apos;échappement)",
     "name" : "ESDC - MSCA Feedback Form",
     "survey-urls" : [
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test4-eng.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test4-fra.html"}
+			{ "url" : "/invitation-manager/docs/test-IM/test4-eng.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test4-fra.html"}
 	
     ]
   },
@@ -177,8 +177,8 @@
     "close-fr" : "Fermer : Sondage de fin de visite (touche d&apos;échappement)",
     "name" : "ESDC - MSCA Feedback Form",
     "survey-urls" : [
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test5-eng.html"},
-			{ "url" : "https://servicecanada.github.io/invitation-manager/docs/test-IM/test5-fra.html"}
+			{ "url" : "/invitation-manager/docs/test-IM/test5-eng.html"},
+			{ "url" : "/invitation-manager/docs/test-IM/test5-fra.html"}
 
     ]
   }

--- a/docs/test-IM/test-eng.html
+++ b/docs/test-IM/test-eng.html
@@ -1,227 +1,224 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en" dir="ltr">
-<head>
-	<meta charset="utf-8">
-	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-	<title>Invitation Manager working example - test-eng.html page</title>
-	<meta content="width=device-width, initial-scale=1" name="viewport">
-	<meta name="description" content=" " />
-	<link href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon" />
-	<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css" />
-	<noscript>
-		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
-	</noscript>
-	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
-	<!-- Invitation Manager CSS Files -->
-</head>
-
-<body vocab="http://schema.org/" typeof="WebPage">
-	<nav>
-		<ul id="wb-tphp">
-			<li class="wb-slc"><a class="wb-sl" href="#wb-cont">Skip to main content</a></li>
-			<li class="wb-slc visible-sm visible-md visible-lg">
-				<a class="wb-sl" href="#wb-info">Skip to About this
-					site</a>
-			</li>
-		</ul>
-	</nav>
-
-	<header>
-		<div id="wb-bnr" class="container">
-			<div class="row">
-				<section id="wb-lng" class="col-xs-3 col-sm-12 pull-right text-right">
-					<h2 class="wb-inv">Language selection</h2>
-					<ul class="list-inline mrgn-bttm-0">
-						<li>
-							<a lang="fr" hreflang="fr" href="accueil.html">
-								<span class="hidden-xs">Français</span>
-								<abbr title="Français"
-									class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">fr</abbr>
-							</a>
-						</li>
-					</ul>
-				</section>
-				<div class="brand col-xs-9 col-sm-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
-					<a href="https://wet-boew.github.io/gcweb/" property="url">
-						<img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"
-							alt="Government of Canada" property="logo" /><span class="wb-inv"> / <span
-								lang="fr">Gouvernement du Canada</span></span>
-					</a>
-					<meta property="name" content="Government of Canada">
-					<meta property="areaServed" typeof="Country" content="Canada" />
-					<link property="logo"
-						href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" />
-				</div>
-				<section id="wb-srch"
-					class="col-lg-offset-4 col-md-offset-4 col-sm-offset-2 col-xs-12 col-sm-5 col-md-4">
-					<h2>Search</h2>
-					<form action="#" method="post" name="cse-search-box" role="search">
-						<div class="form-group wb-srch-qry">
-							<label for="wb-srch-q" class="wb-inv">Search Canada.ca</label>
-							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q"
-								type="search" value="" size="34" maxlength="170" placeholder="Search Canada.ca" />
-							<datalist id="wb-srch-q-ac"></datalist>
-						</div>
-						<div class="form-group submit">
-							<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
-								<span class="glyphicon-search glyphicon"></span>
-								<span class="wb-inv">Search</span>
-							</button>
-						</div>
-					</form>
-				</section>
-			</div>
-		</div>
-		<nav class="gcweb-menu" typeof="SiteNavigationElement">
-			<div class="container">
-				<h2 class="wb-inv">Menu</h2>
-				<button type="button" aria-haspopup="true" aria-expanded="false"><span class="wb-inv">Main </span>Menu
-					<span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-				<ul role="menu" aria-orientation="vertical"
-					data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
-					<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/jobs.html">Jobs
-							and the workplace</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and
-							citizenship</a></li>
-					<li role="presentation"><a role="menuitem" href="https://travel.gc.ca/">Travel and tourism</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/health.html">Health</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/environment.html">Environment and natural
-							resources</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
-					</li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
-					</li>
-					<li role="presentation"><a role="menuitem"
-							href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
-					</li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-					<li role="presentation"><a role="menuitem"
-							href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
-				</ul>
-			</div>
+	<head>
+		<meta charset="utf-8">
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+		<title>Invitation Manager working example - test-eng.html page</title>
+		<meta content="width=device-width, initial-scale=1" name="viewport">
+		<meta name="description" content=" " />
+		<link href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon" />
+		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css" />
+		<noscript>
+			<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
+		</noscript>
+		<!-- Invitation Manager CSS Files -->
+		<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
+		<!-- Invitation Manager CSS Files -->
+	</head>
+	<body vocab="http://schema.org/" typeof="WebPage">
+		<nav>
+			<ul id="wb-tphp">
+				<li class="wb-slc"><a class="wb-sl" href="#wb-cont">Skip to main content</a></li>
+				<li class="wb-slc visible-sm visible-md visible-lg">
+					<a class="wb-sl" href="#wb-info">Skip to About this site</a>
+				</li>
+			</ul>
 		</nav>
-		<nav id="wb-bc" property="breadcrumb">
-			<h2>You are here:</h2>
-			<div class="container">
-				<ol class="breadcrumb">
-					<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>
-				</ol>
-			</div>
-		</nav>
-	</header>
-
-	<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-		<h1 id="wb-cont" property="name">Invitation Manager working example - test-eng</h1>
-		<div class="row">
-			<div class="col-md-7 col-lg-8">
-				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin est nibh, pellentesque gravida venenatis ut, pulvinar sed quam. Nunc non lobortis purus. Etiam viverra purus metus, ac imperdiet orci accumsan sit amet. Nullam quis feugiat ante. Quisque dignissim iaculis metus, ac congue nisl porttitor id. Vestibulum ultricies augue facilisis mi maximus, vel pulvinar leo consectetur. Vestibulum ac lectus sed lectus mattis consectetur at sit amet eros. Curabitur id magna urna. Pellentesque id posuere odio. Sed ut volutpat lacus. Nulla fermentum mi justo. Donec vel augue magna. Quisque accumsan massa massa, at faucibus nibh hendrerit a. Nullam ut elit lectus. Mauris eget felis gravida, luctus lacus sit amet, vulputate lacus.</p>
-			</div>
-			<div class="col-xs-12 col-md-auto pull-right">
-				<p>Ut sed nunc lacus. Morbi vestibulum, mi non auctor malesuada, libero velit commodo nisi, lobortis pretium velit tortor in nulla. Integer lorem quam, hendrerit tincidunt urna a, laoreet condimentum urna.</p>
-			</div>
-		</div>
-
-		<ul class="colcount-md-2">
-			<li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
-			<li>Phasellus ut erat vel nulla feugiat semper.</li>
-			<li>Quisque a lorem ultrices, tristique dui et, vehicula nulla.</li>
-			<li>Duis feugiat ex at sapien dictum semper.</li>			
-		</ul>
-		<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam blandit sollicitudin bibendum. Pellentesque posuere ante non ullamcorper elementum. Cras sit amet metus facilisis, lacinia urna eu, gravida justo. Suspendisse feugiat consequat justo id elementum. Maecenas tempor ornare purus sed interdum. Duis semper lobortis tortor, eu venenatis augue volutpat vel. Sed imperdiet, augue eget facilisis posuere, turpis velit sagittis orci, eu consectetur mauris elit non urna. Donec sed ornare nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dapibus eu mi eu elementum. Nunc iaculis magna velit, et consectetur orci suscipit nec. Nam mollis accumsan neque in dignissim. Ut pretium, metus non ullamcorper molestie, ex est ullamcorper lorem, in maximus neque nisl ac urna. Cras varius nisl id mauris feugiat dapibus.
-		</p>
-		<p>
-		Mauris quis sapien auctor, fermentum ex eget, condimentum massa. Etiam at pulvinar lacus, sed placerat dui. Fusce fermentum arcu a lacus blandit tincidunt. Etiam fermentum turpis in ipsum facilisis laoreet. Vivamus eget odio eros. Donec est dui, auctor lobortis luctus a, dictum hendrerit felis. Donec sit amet molestie elit. Vestibulum mattis justo sed leo pellentesque, eget semper tellus viverra. In aliquam mi a lacus vulputate vulputate. Vestibulum vitae purus ornare, blandit odio finibus, porta ex. Duis id porta dui.
-		</p>
-		<p>
-		Sed at volutpat lorem. Suspendisse lobortis tellus nec felis congue, eget semper risus bibendum. Integer nec enim laoreet, aliquam metus vitae, porttitor dui. Phasellus convallis sollicitudin risus, posuere malesuada lorem fringilla ut. In in faucibus nulla, sed rutrum purus. Vestibulum porta ac justo sit amet porttitor. Fusce non diam placerat, tincidunt risus a, imperdiet mi. Donec cursus id elit at pellentesque. Duis leo erat, mattis vitae posuere nec, egestas nec diam. Etiam consectetur enim ex, eget dignissim erat bibendum id. Curabitur efficitur gravida leo id laoreet. Fusce egestas nibh eget libero pretium pellentesque. Vivamus imperdiet, augue fringilla posuere vulputate, mi metus pretium neque, sed eleifend ante lorem ac est. Nullam volutpat in sem eu viverra. Curabitur eu libero mauris. Proin vulputate interdum imperdiet.
-		</p>
-		<div class="pagedetails container">
-			<dl id="wb-dtmd">
-				<dt>Date modified: </dt>
-				<dd><time property="dateModified">2021-11-30</time></dd>
-			</dl>
-		</div>
-
-	</main>
-
-	<footer id="wb-info">
-		<div class="landscape">
-			<nav class="container wb-navcurr">
-				<h2 class="wb-inv">About government</h2>
-				<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-					<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
-					<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
-					<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
-					</li>
-					<li><a href="https://www.canada.ca/en/news.html">News</a></li>
-					<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and
-							regulations</a></li>
-					<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
-					</li>
-					<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
-					<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
-					<li><a href="https://open.canada.ca/en/">Open government</a></li>
-				</ul>
-			</nav>
-		</div>
-		<div class="brand">
-			<div class="container">
-				<div class="row ">
-					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-						<h2 class="wb-inv">About this site</h2>
-						<ul>
-							<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
-							<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
-							<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
-							<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-							<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+		<header>
+			<div id="wb-bnr" class="container">
+				<div class="row">
+					<section id="wb-lng" class="col-xs-3 col-sm-12 pull-right text-right">
+						<h2 class="wb-inv">Language selection</h2>
+						<ul class="list-inline mrgn-bttm-0">
+							<li>
+								<a lang="fr" hreflang="fr" href="accueil.html">
+									<span class="hidden-xs">Français</span>
+									<abbr title="Français"
+										class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">fr</abbr>
+								</a>
+							</li>
 						</ul>
-					</nav>
-					<div class="col-xs-6 visible-sm visible-xs tofpg">
-						<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+					</section>
+					<div class="brand col-xs-9 col-sm-5 col-md-4" property="publisher" typeof="GovernmentOrganization">
+						<a href="https://wet-boew.github.io/gcweb/" property="url">
+							<img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"
+								alt="Government of Canada" property="logo" /><span class="wb-inv"> / <span
+									lang="fr">Gouvernement du Canada</span></span>
+						</a>
+						<meta property="name" content="Government of Canada">
+						<meta property="areaServed" typeof="Country" content="Canada" />
+						<link property="logo"
+							href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg" />
 					</div>
-					<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-						<img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg"
-							alt="Symbol of the Government of Canada" />
+					<section id="wb-srch"
+						class="col-lg-offset-4 col-md-offset-4 col-sm-offset-2 col-xs-12 col-sm-5 col-md-4">
+						<h2>Search</h2>
+						<form action="#" method="post" name="cse-search-box" role="search">
+							<div class="form-group wb-srch-qry">
+								<label for="wb-srch-q" class="wb-inv">Search Canada.ca</label>
+								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q"
+									type="search" value="" size="34" maxlength="170" placeholder="Search Canada.ca" />
+								<datalist id="wb-srch-q-ac"></datalist>
+							</div>
+							<div class="form-group submit">
+								<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+									<span class="glyphicon-search glyphicon"></span>
+									<span class="wb-inv">Search</span>
+								</button>
+							</div>
+						</form>
+					</section>
+				</div>
+			</div>
+			<nav class="gcweb-menu" typeof="SiteNavigationElement">
+				<div class="container">
+					<h2 class="wb-inv">Menu</h2>
+					<button type="button" aria-haspopup="true" aria-expanded="false"><span class="wb-inv">Main </span>Menu
+						<span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+					<ul role="menu" aria-orientation="vertical"
+						data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+						<li role="presentation"><a role="menuitem" href="https://www.canada.ca/en/services/jobs.html">Jobs
+								and the workplace</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and
+								citizenship</a></li>
+						<li role="presentation"><a role="menuitem" href="https://travel.gc.ca/">Travel and tourism</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/health.html">Health</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/environment.html">Environment and natural
+								resources</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
+						</li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
+						</li>
+						<li role="presentation"><a role="menuitem"
+								href="https://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
+						</li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
+						<li role="presentation"><a role="menuitem"
+								href="https://www.canada.ca/en/services/science.html">Science and innovation</a></li>
+					</ul>
+				</div>
+			</nav>
+			<nav id="wb-bc" property="breadcrumb">
+				<h2>You are here:</h2>
+				<div class="container">
+					<ol class="breadcrumb">
+						<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>
+					</ol>
+				</div>
+			</nav>
+		</header>
+
+		<main class="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
+			<h1 id="wb-cont" property="name">Invitation Manager working example - test-eng</h1>
+			<div class="row">
+				<div class="col-md-7 col-lg-8">
+					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin est nibh, pellentesque gravida venenatis ut, pulvinar sed quam. Nunc non lobortis purus. Etiam viverra purus metus, ac imperdiet orci accumsan sit amet. Nullam quis feugiat ante. Quisque dignissim iaculis metus, ac congue nisl porttitor id. Vestibulum ultricies augue facilisis mi maximus, vel pulvinar leo consectetur. Vestibulum ac lectus sed lectus mattis consectetur at sit amet eros. Curabitur id magna urna. Pellentesque id posuere odio. Sed ut volutpat lacus. Nulla fermentum mi justo. Donec vel augue magna. Quisque accumsan massa massa, at faucibus nibh hendrerit a. Nullam ut elit lectus. Mauris eget felis gravida, luctus lacus sit amet, vulputate lacus.</p>
+				</div>
+				<div class="col-xs-12 col-md-auto pull-right">
+					<p>Ut sed nunc lacus. Morbi vestibulum, mi non auctor malesuada, libero velit commodo nisi, lobortis pretium velit tortor in nulla. Integer lorem quam, hendrerit tincidunt urna a, laoreet condimentum urna.</p>
+				</div>
+			</div>
+
+			<ul class="colcount-md-2">
+				<li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+				<li>Phasellus ut erat vel nulla feugiat semper.</li>
+				<li>Quisque a lorem ultrices, tristique dui et, vehicula nulla.</li>
+				<li>Duis feugiat ex at sapien dictum semper.</li>			
+			</ul>
+			<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam blandit sollicitudin bibendum. Pellentesque posuere ante non ullamcorper elementum. Cras sit amet metus facilisis, lacinia urna eu, gravida justo. Suspendisse feugiat consequat justo id elementum. Maecenas tempor ornare purus sed interdum. Duis semper lobortis tortor, eu venenatis augue volutpat vel. Sed imperdiet, augue eget facilisis posuere, turpis velit sagittis orci, eu consectetur mauris elit non urna. Donec sed ornare nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dapibus eu mi eu elementum. Nunc iaculis magna velit, et consectetur orci suscipit nec. Nam mollis accumsan neque in dignissim. Ut pretium, metus non ullamcorper molestie, ex est ullamcorper lorem, in maximus neque nisl ac urna. Cras varius nisl id mauris feugiat dapibus.
+			</p>
+			<p>
+			Mauris quis sapien auctor, fermentum ex eget, condimentum massa. Etiam at pulvinar lacus, sed placerat dui. Fusce fermentum arcu a lacus blandit tincidunt. Etiam fermentum turpis in ipsum facilisis laoreet. Vivamus eget odio eros. Donec est dui, auctor lobortis luctus a, dictum hendrerit felis. Donec sit amet molestie elit. Vestibulum mattis justo sed leo pellentesque, eget semper tellus viverra. In aliquam mi a lacus vulputate vulputate. Vestibulum vitae purus ornare, blandit odio finibus, porta ex. Duis id porta dui.
+			</p>
+			<p>
+			Sed at volutpat lorem. Suspendisse lobortis tellus nec felis congue, eget semper risus bibendum. Integer nec enim laoreet, aliquam metus vitae, porttitor dui. Phasellus convallis sollicitudin risus, posuere malesuada lorem fringilla ut. In in faucibus nulla, sed rutrum purus. Vestibulum porta ac justo sit amet porttitor. Fusce non diam placerat, tincidunt risus a, imperdiet mi. Donec cursus id elit at pellentesque. Duis leo erat, mattis vitae posuere nec, egestas nec diam. Etiam consectetur enim ex, eget dignissim erat bibendum id. Curabitur efficitur gravida leo id laoreet. Fusce egestas nibh eget libero pretium pellentesque. Vivamus imperdiet, augue fringilla posuere vulputate, mi metus pretium neque, sed eleifend ante lorem ac est. Nullam volutpat in sem eu viverra. Curabitur eu libero mauris. Proin vulputate interdum imperdiet.
+			</p>
+			<div class="pagedetails container">
+				<dl id="wb-dtmd">
+					<dt>Date modified: </dt>
+					<dd><time property="dateModified">2021-11-30</time></dd>
+				</dl>
+			</div>
+
+		</main>
+
+		<footer id="wb-info">
+			<div class="landscape">
+				<nav class="container wb-navcurr">
+					<h2 class="wb-inv">About government</h2>
+					<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+						<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
+						<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
+						<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
+						</li>
+						<li><a href="https://www.canada.ca/en/news.html">News</a></li>
+						<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and
+								regulations</a></li>
+						<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
+						</li>
+						<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
+						<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
+						<li><a href="https://open.canada.ca/en/">Open government</a></li>
+					</ul>
+				</nav>
+			</div>
+			<div class="brand">
+				<div class="container">
+					<div class="row ">
+						<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+							<h2 class="wb-inv">About this site</h2>
+							<ul>
+								<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
+								<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
+								<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
+								<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
+								<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+							</ul>
+						</nav>
+						<div class="col-xs-6 visible-sm visible-xs tofpg">
+							<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+						</div>
+						<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+							<img src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/wmms-blk.svg"
+								alt="Symbol of the Government of Canada" />
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	</footer>
+		</footer>
 
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"
-		integrity="sha384-rY/jv8mMhqDabXSo+UCggqKtdmBfd3qC2/KvyTDNQ6PcUJXaxK1tMepoQda4g5vB"
-		crossorigin="anonymous"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"
+			integrity="sha384-rY/jv8mMhqDabXSo+UCggqKtdmBfd3qC2/KvyTDNQ6PcUJXaxK1tMepoQda4g5vB"
+			crossorigin="anonymous"></script>
+		<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+		<script src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
-	<!-- used to check for the path of config.JSON file. 
-		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
-	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
-	</script>
+		<!-- used to check for the path of config.JSON file. 
+			If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
+		<script>
+			window.imConfigPath = "/invitation-manager/docs/";
+		</script>
 
-	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
-	<!-- End Invitation Manager JS Files-->
-</body>
+		<!-- Invitation Manager JS Files -->
+		<script src="/invitation-manager/src/Overlay.js"></script>
+		<script src="/invitation-manager/src/InvitationManager.js"></script>
+		<!-- End Invitation Manager JS Files-->
+	</body>
 </html>

--- a/docs/test-IM/test-fra.html
+++ b/docs/test-IM/test-fra.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test2-eng.html
+++ b/docs/test-IM/test2-eng.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test2-fra.html
+++ b/docs/test-IM/test2-fra.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test3-eng.html
+++ b/docs/test-IM/test3-eng.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test3-fra.html
+++ b/docs/test-IM/test3-fra.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test4-eng.html
+++ b/docs/test-IM/test4-eng.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test4-fra.html
+++ b/docs/test-IM/test4-fra.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test5-eng.html
+++ b/docs/test-IM/test5-eng.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/docs/test-IM/test5-fra.html
+++ b/docs/test-IM/test5-fra.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/css/noscript.min.css" />
 	</noscript>
 	<!-- Invitation Manager CSS Files -->
-	<link rel="stylesheet" href="https://servicecanada.github.io/invitation-manager/src/Overlay.css">
+	<link rel="stylesheet" href="/invitation-manager/src/Overlay.css">
 	<!-- Invitation Manager CSS Files -->
 </head>
 
@@ -215,12 +215,12 @@
 	<!-- used to check for the path of config.JSON file. 
 		If not declared, config.JSON is expected to be in the same directory as InvitationManger.js -->
 	<script>
-		window.imConfigPath = "https://servicecanada.github.io/invitation-manager/docs/";
+		window.imConfigPath = "/invitation-manager/docs/";
 	</script>
 
 	<!-- Invitation Manager JS Files -->
-	<script src="https://servicecanada.github.io/invitation-manager/src/Overlay.js"></script>
-	<script src="https://servicecanada.github.io/invitation-manager/src/InvitationManager.js"></script>
+	<script src="/invitation-manager/src/Overlay.js"></script>
+	<script src="/invitation-manager/src/InvitationManager.js"></script>
 	<!-- End Invitation Manager JS Files-->
 </body>
 </html>

--- a/src/InvitationManager.js
+++ b/src/InvitationManager.js
@@ -571,15 +571,22 @@ function imSetup() {
 	 * Display the popup given the survey parameters
 	 */
 	function invite(survey) {
+		var referrerPath = encodeURIComponent(window.location.pathname),
+			surveyLink = survey["link-" + wb_im.lang],
+			delimiter = "?",
+			popupInput;
 
-		var popupInput
+		if ( surveyLink.includes( "?" ) ) {
+			delimiter = "&";
+		}
+
 		if (Adobe.toLowerCase() === "yes")
 		{
-			popupInput = "<input type='hidden' name='popupName' value='" + survey["name"] + "'>" 
+			popupInput = "<input type='hidden' name='popupName' value='" + survey["name"] + "'>";
 		} 
 		else
 		{
-			popupInput = "" 
+			popupInput = "";
 		}
 	
 		var html =  
@@ -595,7 +602,7 @@ function imSetup() {
 			"<div class='gc-im-modal-body'>" +
 				survey["body-" + wb_im.lang] +
 				"<ul class='list-inline mrgn-sm'>" +
-			"<li class='mrgn-sm marginBottom-yes'><a id='survey-yes' class='gc-im-btn gc-im-btn-primary' href='" + survey["link-" + wb_im.lang] + "' target='_blank' referrer-policy='unsafe-url'>" + survey["yes-" + wb_im.lang] + "</a></li> " + 
+			"<li class='mrgn-sm marginBottom-yes'><a id='survey-yes' class='gc-im-btn gc-im-btn-primary' href='" + survey["link-" + wb_im.lang] + delimiter + "ref=" + referrerPath + "' target='_blank' referrer-policy='unsafe-url'>" + survey["yes-" + wb_im.lang] + "</a></li> " + 
 					"<li class='mrgn-sm marginBottom-no'><button id='survey-no' class='gc-im-btn gc-im-btn-secondary survey-close'>" + survey["no-" + wb_im.lang] + "</button></li>" +
 				"</ul>" +
 				popupInput +


### PR DESCRIPTION
- Finding an alternative for providing the referrer path following the domain name.
- Using `window.location.pathname` to fetch everything following the domain name and add it pass it via a URL parameter.
- From the task success survey, fetching the URL parameter and concatenate it  to the domain name in `document.referrer`.

Working example: https://ricokola.github.io/invitation-manager/docs/test-IM/test-eng.html?logim=1&im_scope=Page&im_surveyid=4&im_nocookiecheck=1&im_nodatecheck=1